### PR TITLE
Attempt to fix mmx code

### DIFF
--- a/LIB386/3D/IROT3DM.ASM
+++ b/LIB386/3D/IROT3DM.ASM
@@ -86,7 +86,7 @@ InverseRotatePointM	PROC
 
 		psrad		mm4, 14
 
-		movd		[X0], mm0
+		movq		qword ptr [X0], mm0
 
 		movd		[Z0], mm4
 

--- a/LIB386/3D/LIROT3DM.ASM
+++ b/LIB386/3D/LIROT3DM.ASM
@@ -105,7 +105,7 @@ LongInverseRotatePointM proc
 
 		psrad		mm4, 13		; mm4 = Zl'Z  Zl'XY		3
 
-		movd		[X0], mm0
+		movq		qword ptr [X0], mm0
 		paddd		mm4, mm5	; mm4 =  Z'Z   Z'XY		3
 
 		movq		mm5, mm4	; mm5 =  Z'Z   Z'XY		3

--- a/LIB386/3D/LROT3DM.ASM
+++ b/LIB386/3D/LROT3DM.ASM
@@ -86,7 +86,7 @@ LongRotatePointM proc
 
 		psrad		mm6, 13		; mm6 = Zl'Z  Zl'XY		3
 
-		movd		[X0], mm0
+		movq		qword ptr [X0], mm0
 		paddd		mm6, mm7	; mm6 =  Z'Z   Z'XY		3
 
 		movq		mm7, mm6	; mm7 =  Z'Z   Z'XY		3

--- a/LIB386/3D/LROTLISM.ASM
+++ b/LIB386/3D/LROTLISM.ASM
@@ -49,12 +49,12 @@ LongRotateListM	proc
 NextPoint:
 		movq		mm6, [esi+ecx]	; mm6 = Yh Yl Xh Xl
 
-		movq		mm5, [esi+ecx+8]; mm5 = 0  0  Zh Zl
+		movd		mm5, [esi+ecx+8]; mm5 = 0  0  Zh Zl
 
 		movq		mm4, mm5	; mm4 = 0  0  Zh Zl
 		movq		mm7, mm6	; mm6 = Yh Yl Xh Xl
 
-		movq		mm7, [esi+ecx+4]; mm7 = 0  0  Yh Yl
+		movd		mm7, [esi+ecx+4]; mm7 = 0  0  Yh Yl
 		psllq		mm5, 16		; mm5 = 0  Zh Zl 0
 
 		movq		mm0, [ebx]	; mm0 = 0  3  2  1		1
@@ -114,7 +114,7 @@ NextPoint:
 		movq		[edi+ecx], mm0
 		paddd		mm5, mm4	; mm5 =   .    Z'		3
 
-		movq		[edi+ecx+8], mm5
+		movd		[edi+ecx+8], mm5
 
 		add		ecx, 12
 		jnz		NextPoint

--- a/LIB386/3D/LROTRLIM.ASM
+++ b/LIB386/3D/LROTRLIM.ASM
@@ -48,7 +48,7 @@ LongRotTransListM	proc
 NextPoint:
 		movq		mm6, [esi+ecx]	; mm6 = Yh Yl Xh Xl
 
-		movq		mm5, [esi+ecx+8]; mm5 = 0  0  Zh Zl
+		movd		mm5, [esi+ecx+8]; mm5 = 0  0  Zh Zl
 		paddd		mm6, mm6
 
 		movq		mm7, mm6	; mm6 = Yh Yl Xh Xl
@@ -56,7 +56,7 @@ NextPoint:
 
 		movq		mm4, mm5	; mm4 = 0  0  Zh Zl
 
-		movq		mm7, [esi+ecx+4]; mm7 = 0  0  Yh Yl
+		movd		mm7, [esi+ecx+4]; mm7 = 0  0  Yh Yl
 		psllq		mm5, 16		; mm5 = 0  Zh Zl 0
 
 		movq		mm0, [ebx]	; mm0 = 0  3  2  1		1
@@ -120,7 +120,7 @@ NextPoint:
 
 		paddd		mm5, [ebx+40]	; mm5 =   .    Z'  + LONG TRANS
 
-		movq		[edi+ecx+8], mm5
+		movd		[edi+ecx+8], mm5
 
 		add		ecx, 12
 		jnz		NextPoint

--- a/LIB386/3D/ROT3DM.ASM
+++ b/LIB386/3D/ROT3DM.ASM
@@ -67,7 +67,7 @@ RotatePointM	proc
 
 		psrad		mm2, 14		; mm1 =  .     Z'
 
-		movd		[X0], mm5
+		movq		qword ptr [X0], mm5
 
 		;
 

--- a/LIB386/H/INITADEL.C
+++ b/LIB386/H/INITADEL.C
@@ -223,11 +223,6 @@
 	if(!FindAndRemoveParam("/CPUNodetect"))
 	{
 		ProcessorIdentification();
-
-		if (ProcessorFeatureFlags.MMX) {
-			LogPuts("MMX support detected... overriding");
-			ProcessorFeatureFlags.MMX = 0;
-		}
 	}
 
 	DisplayCPU()			;

--- a/LIB386/POL_WORK/TESTVUEM.ASM
+++ b/LIB386/POL_WORK/TESTVUEM.ASM
@@ -25,12 +25,12 @@ TestVuePolyM		PROC	; Pentium 13
 ;(x2-x1)*(y1-y3)-(y2-y1)*(x1-x3)
 ;   P1  *  P2   -   P3  *  P4
 
-			movq		mm0, [esi]	; .  . Y0 X0
+			movd		mm0, [esi]	; .  . Y0 X0
 
-			movq		mm1, [esi+16]	; .  . Y1 X1
+			movd		mm1, [esi+16]	; .  . Y1 X1
 			movq		mm3, mm0
 
-			movq		mm2, [esi+32]	; .  . Y2 X2
+			movd		mm2, [esi+32]	; .  . Y2 X2
 			punpcklwd	mm0, mm1	; MM0 = Y1 Y0 X1 X0
 
 			punpcklwd	mm3, mm2	; MM3 = Y2 Y0 X2 X0

--- a/LIB386/SVGA/CLEABOVM.ASM
+++ b/LIB386/SVGA/CLEABOVM.ASM
@@ -47,7 +47,7 @@ ClearBoxVESAM		PROC
 			shr	ebp, 16
 			and	eax, 0FFFFh
 
-			movd	mm0, [ClearColor]
+			movq	mm0, qword ptr [ClearColor]
 			mov	ecx, ebx
 
 			add	edi, [edx+ebp*4]

--- a/LIB386/SVGA/CLRBOXM.ASM
+++ b/LIB386/SVGA/CLRBOXM.ASM
@@ -51,7 +51,7 @@ ClearBoxM		PROC
 			sub 	ebx, esi		; deltaY
 			mov	ecx, eax
 
-			movd	mm0, [ClearColor]
+			movq	mm0, qword ptr [ClearColor]
 
 			test	eax, 8
 			jnz	odd


### PR DESCRIPTION
Some assembly instructions were wrongly changed when trying to make the code compatible with JWasm without MASM 5.1 compatibility mode enabled